### PR TITLE
Fix of nonexistent dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.0.3",
   "license": "MIT",
   "dependencies": {
-    "visionmedia/node-concat-stream": "0.0.1"
+    "concat-stream": "0.0.1"
   },
   "devDependencies": {
     "mocha": "~1.15.1"


### PR DESCRIPTION
The package "visionmedia/node-concat-stream" does not seem to exist anymore, changed the depency.
